### PR TITLE
UIDatePicker support

### DIFF
--- a/RMPickerViewController-Demo/Main.storyboard
+++ b/RMPickerViewController-Demo/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="79U-h7-59M">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6750" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="79U-h7-59M">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6735"/>
     </dependencies>
     <scenes>
         <!--Demo-->
@@ -27,7 +27,7 @@
                                                     <rect key="frame" x="15" y="11" width="116" height="21"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jPP-2K-vHN">
@@ -35,6 +35,30 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="9Bk-ga-DiB" detailTextLabel="MoO-Iw-tQh" style="IBUITableViewCellStyleValue1" id="hAA-rC-aQa">
+                                        <rect key="frame" x="0.0" y="99" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hAA-rC-aQa" id="ZLb-Ep-jyM">
+                                            <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Show date picker view controller…" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Bk-ga-DiB">
+                                                    <rect key="frame" x="15" y="11" width="116" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MoO-Iw-tQh">
+                                                    <rect key="frame" x="241" y="11" width="44" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -57,7 +81,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Black Version" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="szT-2l-kBo">
                                                     <rect key="frame" x="15" y="11" width="104" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="DrY-8g-Irc">
@@ -86,7 +110,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w1h-Oh-jiK">
                                                     <rect key="frame" x="15" y="11" width="89" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NkY-Wb-elX">
@@ -111,7 +135,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Motion Effects" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldS-Vs-qdP">
                                                     <rect key="frame" x="15" y="11" width="111" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="idC-O0-DcP">
@@ -136,7 +160,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bouncing Effects" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Iw-j8-nzk">
                                                     <rect key="frame" x="15" y="11" width="131" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vaU-lb-FHs">

--- a/RMPickerViewController-Demo/RMViewController.m
+++ b/RMPickerViewController-Demo/RMViewController.m
@@ -100,10 +100,79 @@
     }
 }
 
+- (IBAction)openDatePickerController:(id)sender {
+    
+    RMPickerViewController *pickerVC = [RMPickerViewController pickerControllerWithType:RMPickerTypeDate];
+    
+    // It's not allowed to set the delegate with `RMPickerTypeDate`
+    //pickerVC.delegate = self;
+    
+    pickerVC.titleLabel.text = @"This is an example title.\n\nPlease choose a row and press 'Select' or 'Cancel'.";
+    
+    //You can enable or disable bouncing and motion effects
+    pickerVC.disableBouncingWhenShowing = !self.bouncingSwitch.on;
+    pickerVC.disableMotionEffects = !self.motionSwitch.on;
+    pickerVC.disableBlurEffects = !self.blurSwitch.on;
+    
+    //You can also adjust colors (enabling the following line will result in a black version of RMPickerViewController)
+    if(self.blackSwitch.on)
+        pickerVC.blurEffectStyle = UIBlurEffectStyleDark;
+    
+    //Enable the following lines if you want a black version of RMPickerViewController but also disabled blur effects (or run on iOS 7)
+    //pickerVC.tintColor = [UIColor whiteColor];
+    //pickerVC.backgroundColor = [UIColor colorWithWhite:0.25 alpha:1];
+    //pickerVC.selectedBackgroundColor = [UIColor colorWithWhite:0.4 alpha:1];
+    
+    //The example project is universal. So we first need to check whether we run on an iPhone or an iPad.
+    if([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        //OK, running on an iPhone. The following lines demonstrate the two ways to show the picker view controller on iPhones:
+        //(Note: These two methods also work an iPads.)
+        
+        // 1. Just show the picker view controller (make sure the delegate property is assigned)
+        [pickerVC show];
+        
+        // 2. Instead of using a delegate you can also pass blocks when showing the picker view controller
+        //[pickerVC showWithSelectionHandler:^(RMPickerViewController *vc, NSArray *selectedRows) {
+        //    NSLog(@"Successfully selected rows: %@", selectedRows);
+        //} andCancelHandler:^(RMPickerViewController *vc) {
+        //    NSLog(@"Row selection was canceled (with block)");
+        //}];
+    } else if([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        //OK, running on an iPad. The following lines demonstrate the two special ways of showing the picker view controller on iPads:
+        
+        // 1. Show the picker view controller from a particular view controller (make sure the delegate property is assigned).
+        //    This method can be used to show the picker view controller within popovers.
+        //    (Note: We do not use self as the view controller, as showing a picker view controller from a table view controller
+        //           is not supported due to UIKit limitations.)
+        //[pickerVC showFromViewController:self.navigationController];
+        
+        // 2. As with the two ways of showing the picker view controller on iPhones, we can also use a blocks based API.
+        //[pickerVC showFromViewController:self.navigationController withSelectionHandler:^(RMPickerViewController *vc, NSArray *selectedRows) {
+        //    NSLog(@"Successfully selected rows: %@", selectedRows);
+        //} andCancelHandler:^(RMPickerViewController *vc) {
+        //    NSLog(@"Row selection was canceled (with block)");
+        //}];
+        
+        // 3. Show the date selection view controller using a UIPopoverController. The rect and the view are used to tell the
+        //    UIPopoverController where to show up.
+        [pickerVC showFromRect:[self.tableView rectForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]] inView:self.view];
+        
+        // 4. The date selectionview controller can also be shown within a popover while also using blocks based API.
+        //[pickerVC showFromRect:[self.tableView rectForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]] inView:self.tableView withSelectionHandler:^(RMPickerViewController *vc, NSArray *selectedRows) {
+        //    NSLog(@"Successfully selected rows: %@", selectedRows);
+        //} andCancelHandler:^(RMPickerViewController *vc) {
+        //    NSLog(@"Row selection was canceled (with block)");
+        //}];
+    }
+    
+}
+
 #pragma mark - UITableView Delegates
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if(indexPath.section == 0 && indexPath.row == 0) {
+    if (indexPath.section == 0 && indexPath.row == 0) {
         [self openPickerController:self];
+    } else if (indexPath.section == 0 && indexPath.row == 1) {
+        [self openDatePickerController:self];
     }
     
     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/RMPickerViewController/RMPickerViewController.h
+++ b/RMPickerViewController/RMPickerViewController.h
@@ -37,6 +37,14 @@
 typedef void (^RMSelectionBlock)(RMPickerViewController *vc, NSArray *selectedRows);
 
 /**
+ *  This block is called when the user selects a date if blocks are used.
+ *
+ *  @param vc           The picker view controller that just finished selecting a row.
+ *  @param date         The date that is selected.
+ */
+typedef void (^RMDateSelectionBlock)(RMPickerViewController *vc, NSDate *date);
+
+/**
  *  This block is called when the user cancels if blocks are used.
  *
  *  @param vc The picker view controller that just got canceled.
@@ -72,7 +80,7 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
 @end
 
 /**
- *  RMPickerViewController is an iOS control for selecting a row using UIPickerView in a UIActionSheet like fashion. When a RMPickerViewController is shown the user gets the opportunity to select some rows using a UIPickerView.
+ *  RMPickerViewController is an iOS control for selecting a row using UIPickerView or a date using UIDatePicker in a UIActionSheet like fashion. When a RMPickerViewController is shown the user gets the opportunity to select some rows using a UIPickerView or a date using UIDatePicker.
  *  
  *  RMPickerViewController supports bouncing effects when animating the picker view controller. In addition, motion effects are supported while showing the picker view controller. Both effects can be disabled by using the properties called disableBouncingWhenShowing and disableMotionEffects.
  *
@@ -80,6 +88,16 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
  *
  *  @warning RMPickerViewController is not designed to be reused. Each time you want to display a RMPickerViewController a new instance should be created. If you want to select a specific row before displaying, you can do so by using the picker property.
  */
+
+/**
+ *  Use one of these types with `+pickerControllerWithType:` to get the appropriate picker.
+ *  Using `+pickerController` defaults to `RMPickerTypeNormal`.
+ */
+typedef NS_ENUM(NSUInteger, RMPickerType) {
+    RMPickerTypeNormal = 1,
+    RMPickerTypeDate
+};
+
 @interface RMPickerViewController : UIViewController
 
 /// @name Getting an Instance
@@ -92,6 +110,15 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
  *  @return Returns a new instance of RMPickerViewController.
  */
 + (instancetype)pickerController;
+
+/**
+ *  This returns a new instance of RMPickerViewController for the given type.
+ *
+ *  @warning Always use this class method to get an instance. Do not initialize an instance yourself.
+ *
+ *  @return Returns a new instance of RMPickerViewController for the given type.
+ */
++ (instancetype)pickerControllerWithType:(RMPickerType)type;
 
 /// @name Localization
 
@@ -115,15 +142,22 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
  *  Used to set the delegate.
  *
  *  The delegate must conform to the RMPickerViewControllerDelegate protocol.
+ * 
+ *  @warning If `type` is `RMPickerTypeDate`, `delegate` should not be assigned.
  */
 @property (nonatomic, weak) id<RMPickerViewControllerDelegate> delegate;
 
 /// @name User Interface
 
 /**
- *  Will return the instance of UIPickerView that is used.
+ *  Will return the instance of UIPickerView that is used or `nil` if the type is `RMPickerTypeDate`.
  */
 @property (nonatomic, readonly) UIPickerView *picker;
+
+/**
+ *  Will return the instance of UIDatePicker that is used or `nil` if the type is `RMPickerTypeNormal`.
+ */
+@property (nonatomic, readonly) UIDatePicker *datePicker;
 
 /**
  *  Will return the label that is used as a title for the picker. You can use this property to set a title and to customize the appearance of the title.
@@ -197,7 +231,7 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
 /**
  *  This shows the picker view controller on top of every other view controller using a new UIWindow. The RMPickerViewController will be added as a child view controller of the UIWindows root view controller. The background of the root view controller is used to darken the views behind the RMPickerViewController.
  *
- *  After a row has been selected the selection block will be called. If the user choses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
+ *  After a row has been selected the selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
  *
  *  This method is the preferred method for showing a RMPickerViewController on iPhones and iPads when a block based API is preferred. Nevertheless, there are situations where this method is not sufficient on iPads. An example for this is that the RMPickerViewController shall be shown within an UIPopover. This can be achieved by using [showFromViewController:withSelectionHandler:andCancelHandler:]([RMPickerViewController showFromViewController:withSelectionHandler:andCancelHandler:]).
  *
@@ -207,9 +241,21 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
 - (void)showWithSelectionHandler:(RMSelectionBlock)selectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
 
 /**
+ *  This shows the picker view controller on top of every other view controller using a new UIWindow. The RMPickerViewController will be added as a child view controller of the UIWindows root view controller. The background of the root view controller is used to darken the views behind the RMPickerViewController.
+ *
+ *  After a date has been selected the date selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
+ *
+ *  This method is the preferred method for showing a RMPickerViewController on iPhones and iPads when a block based API is preferred. Nevertheless, there are situations where this method is not sufficient on iPads. An example for this is that the RMPickerViewController shall be shown within an UIPopover. This can be achieved by using [showFromViewController:withDateSelectionHandler:andCancelHandler:]([RMPickerViewController showFromViewController:withDateSelectionHandler:andCancelHandler:]).
+ *
+ *  @param selectionBlock The block to call when the user selects a row.
+ *  @param cancelBlock    The block to call when the user cancels the selection.
+ */
+- (void)showWithDateSelectionHandler:(RMDateSelectionBlock)dateSelectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
+
+/**
  *  This shows the picker view controller as child view controller of the view controller you passed in as parameter. The content of this view controller will be darkened and the picker view controller will be shown on top.
  *
- *  @warning This method should only be used on iPads in situations where [show]([RMPickerViewController show]) is not sufficient (for example, when the RMPickerViewController shoud be shown within an UIPopover). If [show]([RMPickerViewController show]) is sufficient, please use it!
+ *  @warning This method should only be used on iPads in situations where [show]([RMPickerViewController show]) is not sufficient (for example, when the RMPickerViewController should be shown within an UIPopover). If [show]([RMPickerViewController show]) is sufficient, please use it!
  *
  *  @warning Make sure the delegate property is assigned. Otherwise you will not get any calls when a row is selected or the selection has been canceled.
  *
@@ -220,15 +266,28 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
 /**
  *  This shows the picker view controller as child view controller of the view controller you passed in as parameter. The content of this view controller will be darkened and the picker view controller will be shown on top.
  *
- *  After a row has been selected the selection block will be called. If the user choses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
+ *  After a row has been selected the selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
  *
- *  @warning This method should only be used on iPads in situations where [showWithSelectionHandler:andCancelHandler:]([RMPickerViewController showWithSelectionHandler:andCancelHandler:]) is not sufficient (for example, when the RMPickerViewController shoud be shown within an UIPopover). If [showWithSelectionHandler:andCancelHandler:]([RMPickerViewController showWithSelectionHandler:andCancelHandler:]) is sufficient, please use it!
+ *  @warning This method should only be used on iPads in situations where [showWithSelectionHandler:andCancelHandler:]([RMPickerViewController showWithSelectionHandler:andCancelHandler:]) is not sufficient (for example, when the RMPickerViewController should be shown within an UIPopover). If [showWithSelectionHandler:andCancelHandler:]([RMPickerViewController showWithSelectionHandler:andCancelHandler:]) is sufficient, please use it!
  *
  *  @param aViewController The parent view controller of the RMPickerViewController.
  *  @param selectionBlock  The block to call when the user selects a row.
  *  @param cancelBlock     The block to call when the user cancels the selection.
  */
 - (void)showFromViewController:(UIViewController *)aViewController withSelectionHandler:(RMSelectionBlock)selectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
+
+/**
+ *  This shows the picker view controller as child view controller of the view controller you passed in as parameter. The content of this view controller will be darkened and the picker view controller will be shown on top.
+ *
+ *  After a date has been selected the date selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding delegate methods will be called, too.
+ *
+ *  @warning This method should only be used on iPads in situations where [showWithDateSelectionHandler:andCancelHandler:]([RMPickerViewController showWithDateSelectionHandler:andCancelHandler:]) is not sufficient (for example, when the RMPickerViewController should be shown within an UIPopover). If [showWithDateSelectionHandler:andCancelHandler:]([RMPickerViewController showWithDateSelectionHandler:andCancelHandler:]) is sufficient, please use it!
+ *
+ *  @param aViewController      The parent view controller of the RMPickerViewController.
+ *  @param dateSelectionBlock   The block to call when the user selects a date.
+ *  @param cancelBlock          The block to call when the user cancels the selection.
+ */
+- (void)showFromViewController:(UIViewController *)aViewController withDateSelectionHandler:(RMDateSelectionBlock)dateSelectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
 
 /**
  *  This shows the picker view controller within a popover. The popover is initialized with the picker view controller as content view controller and then presented from the rect in the view given as parameters.
@@ -245,7 +304,7 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
 /**
  *  This shows the picker view controller within a popover. The popover is initialized with the picker view controller as content view controller and then presented from the rect in the view given as parameters.
  *
- *  After a row has been selected the selection block will be called. If the user choses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding methods will be called, too.
+ *  After a row has been selected the selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding methods will be called, too.
  *
  *  @warning This method should only be used on iPads. On iPhones please use [show]([RMPickerViewController show]) or [showWithSelectionHandler:andCancelHandler:]([RMPickerViewController showWithSelectionHandler:andCancelHandler:]) instead.
  *
@@ -255,6 +314,20 @@ typedef void (^RMCancelBlock)(RMPickerViewController *vc);
  *  @param cancelBlock    The block to call when the user cancels the selection.
  */
 - (void)showFromRect:(CGRect)aRect inView:(UIView *)aView withSelectionHandler:(RMSelectionBlock)selectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
+
+/**
+ *  This shows the picker view controller within a popover. The popover is initialized with the picker view controller as content view controller and then presented from the rect in the view given as parameters.
+ *
+ *  After a date has been selected the date selection block will be called. If the user chooses to cancel the selection, the cancel block will be called. If you assigned a delegate the corresponding methods will be called, too.
+ *
+ *  @warning This method should only be used on iPads. On iPhones please use [show]([RMPickerViewController show]) or [showWithDateSelectionHandler:andCancelHandler:]([RMPickerViewController showWithDateSelectionHandler:andCancelHandler:]) instead.
+ *
+ *  @param aRect The rect in the given view the popover should be presented from.
+ *  @param aView The view the popover should be presented from.
+ *  @param dateSelectionBlock The block to call when the user selects a date.
+ *  @param cancelBlock    The block to call when the user cancels the selection.
+ */
+- (void)showFromRect:(CGRect)aRect inView:(UIView *)aView withDateSelectionHandler:(RMDateSelectionBlock)dateSelectionBlock andCancelHandler:(RMCancelBlock)cancelBlock;
 
 /// @name Dismissing
 


### PR DESCRIPTION
I have added UIDatePicker support via a `type` property.
In addition to `+pickerController;` initialiser method, date picker controller can be created by passing `RMPickerTypeDate` to `+pickerControllerWithType:` method. 
`+pickerController;` method is still available and defaults to `RMPickerTypeNormal`.

However, there are a few more things to be done for this feature to be considered completed.
`delegate` property can't be set when type is `RMPickerTypeDate`. I've limited this because `RMPickerViewControllerDelegate` protocol also includes `UIPickerViewDelegate` and `UIPickerViewDataSource` protocols and they are unnecessary for `UIDatePicker`.
Currently I'm using this version with block based APIs and `RMPickerTypeDate`, but it should be prevented to use delegate-based APIs.

So you may ask me that why am I sending this PR if this feature is not completed.
I'm sending this to ask for help and make an awareness of a feature like this. I'm kind of got stuck with delegate-block based API support for `RMPickerTypeDate`, as I can't decide what to do.

If you also give some advices or send another PRs based on this, I'd be happy to help in completing this feature.