### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 
 All notable changes to this project will be documented in this file.
 RMPickerViewController adheres to [Semantic Versioning](http://semver.org/).

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you want to show an UIDatePicker instead of an UIPickerView, you may take a l
 
 If you want to show any other control you may want to take a look at [RMActionController](https://github.com/CooperRS/RMActionController).
 
-##Credits
+## Credits
 Code contributions:
 * Denis Andrasec
 	* Bugfixes


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
