### PR TITLE
Add `Cartfile`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "CooperRS/RMActionController" ~> 1.3.1


### PR DESCRIPTION
Right now if one wants to use just `RMPickerViewController` via Carthage, the `RMActionController` dependency is not resolved automatically so it needs to be added to Cartfile manually.

This PR adds missing Cartfile so it can be resolved automatically. It is alternative to already existing https://github.com/CooperRS/RMDateSelectionViewController/pull/85